### PR TITLE
[Fix] SSE 연결에 필요한 API URL 추가

### DIFF
--- a/hooks/useSubscribe.ts
+++ b/hooks/useSubscribe.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-// import { API_URL } from '@/constants/api'
+import { API_URL } from '@/constants/api'
 import { AlarmResponse } from '@/types/vehicle'
 
 export const useSubscribe = () => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- closes #issue-number -->

close #16

## 📋 작업 내용

SSE 연결에 필요한 API URL이 주석 처리되어있어 빌드 시 문제가 발생했습니다. 해당 주석을 비활성화하고 각 환경에서 정상적으로 동작되는지 테스트까지 완료했습니다.

```js
import { useEffect, useState } from 'react'

import { API_URL } from '@/constants/api' // 주석 비활성화
import { AlarmResponse } from '@/types/vehicle'

export const useSubscribe = () => {
    const [alarm, setAlarm] = useState<AlarmResponse[]>([])
    const [error, setError] = useState<Error | null>(null)

    useEffect(() => {
        const url = `${API_URL}/api/v1/alarm/subscribe`
        const eventSource = new EventSource(url, { withCredentials: true })
    // ... 추가 로직
```

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 삭제된 파일/코드
- [ ] ⚙️ 설정 파일 (.env, .gitignore 등)
